### PR TITLE
Fix/integration test

### DIFF
--- a/.github/workflows/common-cicd.yml
+++ b/.github/workflows/common-cicd.yml
@@ -408,7 +408,7 @@ jobs:
 
 
     integration-test:
-        name: Integration test_${{inputs.repo_name}}
+        name: _Integration Test_${{inputs.repo_name}}
         needs: prepare-backup
         runs-on: ${{ needs.prepare-backup.outputs.use_self_hosted == 'true' && 'self-hosted' || 'ubuntu-latest' }}
         environment: ${{inputs.repo_name}}/${{inputs.target_branch}}
@@ -456,6 +456,12 @@ jobs:
                   check-run-id: ${{steps.create-check-run.outputs.check-run-id}}
                   conclusion: ${{ steps.run_integration_test.conclusion == 'success' && 'success' || 'failure' }}
 
+            - name: Post Integration Test notification
+              if: ${{always()}}
+              id: post-integration-test-notification
+              run: |
+                  gh_url="https://api.github.com/repos/${{github.repository}}/actions/runs/${{github.run_id}}/jobs"
+                  bash ${{env.CICD_SCRIPTS_PATH}}/post-integration-test.sh "${{ steps.run_integration_test.conclusion == 'success' && 'success' || 'failure' }}" "$gh_url" "${{env.GH_TOKEN}}" "_Integration Test_"
 
     deploy-server:
         name: _Deploy Server_${{inputs.repo_name}}

--- a/.github/workflows/common-cicd.yml
+++ b/.github/workflows/common-cicd.yml
@@ -265,24 +265,29 @@ jobs:
                   check-run-id: ${{steps.create-check-run.outputs.check-run-id}}
                   conclusion: ${{ steps.run_post_install_unit_test.conclusion == 'success' && 'success' || 'failure' }}
 
-    integration-test:
-        name: Integration test_${{inputs.repo_name}}
+    prepare-backup:
+        name: Prepare backup_${{inputs.repo_name}}
         runs-on: ubuntu-latest
         if: inputs.action == 'deploy'
         environment: ${{inputs.repo_name}}/${{inputs.target_branch}}
+        outputs:
+          server_latest_backup_file_path: ${{ steps.update-server-backup-path.outputs.server_latest_backup_file_path }}
+          check_run_id: ${{ steps.create-check-run.outputs.check-run-id }}
+          use_self_hosted: ${{ steps.get_size.outputs.use_self_hosted }}
         env:
-            LOCAL_BACKUP_FILE_PATH: ${{github.workspace}}/odoo.zip
-            SERVER_TEMPORARY_BACKUP_PATH: /tmp/odoo/backup/${{inputs.repo_name}}/${{inputs.target_branch}}
-            SERVER_LATEST_BACKUP_FILE_PATH: /tmp/odoo/backup/${{inputs.repo_name}}/${{inputs.target_branch}}/.odoo.zip
-            GITHUB_RUN_ATTEMPT: ${{github.run_attempt}}
+          LOCAL_BACKUP_FILE_PATH: ${{github.workspace}}/odoo.zip
+          SERVER_TEMPORARY_BACKUP_PATH: /tmp/odoo/backup/${{inputs.repo_name}}/${{inputs.target_branch}}
+          SERVER_LATEST_BACKUP_FILE_PATH: /tmp/odoo/backup/${{inputs.repo_name}}/${{inputs.target_branch}}/.odoo.zip
+          GITHUB_RUN_ATTEMPT: ${{github.run_attempt}}
 
         steps:
             - uses: actions/checkout@v4
+
             - name: Create Check Run
               uses: ./.github/actions/create-check-run
               id: create-check-run
               with:
-                  name: "Integration test"
+                  name: "Prepare backup"
 
             - name: Test Preparation
               uses: ./.github/actions/prepare-test-data
@@ -291,15 +296,15 @@ jobs:
               # so this case, we should generate a new DB backup
             - name: Make decision to create a new backup on server
               run: |
-                  if [[ -n ${{env.SERVER_BACKUP_PATH}} && ${{env.SERVER_BACKUP_PATH}} != "_" && ${{ env.GITHUB_RUN_ATTEMPT }} == 1 ]]; then
-                    echo "NEED_NEW_SERVER_BACKUP_FILE=0" >> $GITHUB_ENV
-                  else
-                    echo "NEED_NEW_SERVER_BACKUP_FILE=1" >> $GITHUB_ENV
-                  fi
-                  if [[ ${{ env.IGNORE_INTEGRATION_TEST }} == "true" ]]; then
-                    echo "NEED_NEW_SERVER_BACKUP_FILE=-1" >> $GITHUB_ENV
-                    echo "IGNORE_INTEGRATION_TEST_STEPS=1" >> $GITHUB_ENV                
-                  fi
+                if [[ -n ${{env.SERVER_BACKUP_PATH}} && ${{env.SERVER_BACKUP_PATH}} != "_" && ${{ env.GITHUB_RUN_ATTEMPT }} == 1 ]]; then
+                  echo "NEED_NEW_SERVER_BACKUP_FILE=0" >> $GITHUB_ENV
+                else
+                  echo "NEED_NEW_SERVER_BACKUP_FILE=1" >> $GITHUB_ENV
+                fi
+                if [[ ${{ env.IGNORE_INTEGRATION_TEST }} == "true" ]]; then
+                  echo "NEED_NEW_SERVER_BACKUP_FILE=-1" >> $GITHUB_ENV
+                  echo "IGNORE_INTEGRATION_TEST_STEPS=1" >> $GITHUB_ENV                
+                fi
 
             - name: Get the latest backup file from existing backup path on server
               uses: ./.github/actions/ssh-script
@@ -347,7 +352,7 @@ jobs:
                   local_file: ${{ env.CICD_SCRIPTS_PATH }}/server-backup.sh
                   server_file: ${{ env.SERVER_CICD_SCRIPT_FOLDER }}
 
-            - name: "Backup Odoo on server"
+            - name: Backup Odoo on server
               uses: ./.github/actions/ssh-script
               id: backup-on-server
               if: ${{ env.NEED_NEW_SERVER_BACKUP_FILE == 1 }}
@@ -371,8 +376,54 @@ jobs:
                   if [[ -n "$latest_backup_file_path" ]]; then
                     echo "SERVER_LATEST_BACKUP_FILE_PATH=$latest_backup_file_path" >> $GITHUB_ENV
                   fi
+                    
+            - name: Check backup file size
+              id: get_size
+              shell: bash
+              run: |
+                set -euo pipefail
+                echo "use_self_hosted=false" >> "$GITHUB_OUTPUT"
 
-            - name: "Download backup file"
+                if [[ -n "${{ env.SERVER_LATEST_BACKUP_FILE_PATH }}" ]]; then
+                  remote_size=$(ssh -o StrictHostKeyChecking=no \
+                    -p "${{ env.SERVER_SSH_PORT }}" \
+                    "${{ env.SERVER_USER }}@${{ env.SERVER_HOST }}" \
+                    "stat -c%s -- \"${{ env.SERVER_LATEST_BACKUP_FILE_PATH }}\" 2>/dev/null" || true)
+
+                  if [[ "$remote_size" =~ ^[0-9]+$ ]] && (( remote_size > 8*1024*1024*1024 )); then
+                    echo "use_self_hosted=true" >> "$GITHUB_OUTPUT"
+                  fi
+                fi
+
+            - name: Update Check Run
+              uses: ./.github/actions/update-check-run
+              if: ${{always()}}
+              id: update-check-run
+              with:
+                  check-run-id: ${{steps.create-check-run.outputs.check-run-id}}
+                  conclusion: success
+
+
+    integration-test:
+        name: Integration test_${{inputs.repo_name}}
+        needs: prepare-backup
+        runs-on: ${{ needs.prepare-backup.outputs.use_self_hosted == 'true' && 'self-hosted' || 'ubuntu-latest' }}
+        environment: ${{inputs.repo_name}}/${{inputs.target_branch}}
+        env:
+            LOCAL_BACKUP_FILE_PATH: ${{github.workspace}}/odoo.zip
+            SERVER_TEMPORARY_BACKUP_PATH: /tmp/odoo/backup/${{inputs.repo_name}}/${{inputs.target_branch}}
+            SERVER_LATEST_BACKUP_FILE_PATH: /tmp/odoo/backup/${{inputs.repo_name}}/${{inputs.target_branch}}/.odoo.zip
+            GITHUB_RUN_ATTEMPT: ${{github.run_attempt}}
+
+        steps:
+            - uses: actions/checkout@v4
+            - name: Create Check Run
+              uses: ./.github/actions/create-check-run
+              id: create-check-run
+              with:
+                  name: "Integration test"
+
+            - name: Download backup file
               uses: ./.github/actions/scp-ssh
               if: ${{ env.IGNORE_INTEGRATION_TEST_STEPS != 1}}
               with:
@@ -388,7 +439,7 @@ jobs:
                   local_file: ${{ env.LOCAL_BACKUP_FILE_PATH }}
                   server_file: ${{ env.SERVER_LATEST_BACKUP_FILE_PATH }}
 
-            - name: "Run Integration test"
+            - name: Run Integration test
               id: run_integration_test
               if: ${{ env.IGNORE_INTEGRATION_TEST_STEPS != 1}}
               run: |


### PR DESCRIPTION
## Issue: 
các bản backup file quá lớn gây khó khăn hoặc không thể thực hiện bước kiểm thử tích hợp (integration test) trên các GitHub Runner mặc định.

## Solution: 
Trước đây, tất cả các tác vụ kiểm thử tích hợp đều chạy trên GitHub Runner `ubuntu-latest`. Với các file backup có dung lượng lớn (ví dụ: trên 8GB), việc tải về và xử lý file này trên các runner có tài nguyên giới hạn sẽ rất chậm hoặc thậm chí gây lỗi out of memory/disk space.

Để giải quyết triển khai logic lựa chọn runner động cho bước `integration-test`:
1.  **Kiểm tra kích thước file backup:** Trong bước `prepare-backup`, một bước mới đã được thêm vào để kiểm tra kích thước của file backup cuối cùng trên máy chủ từ xa.
2.  **Quyết định loại Runner:**
    * Nếu file backup có kích thước **lớn hơn 8GB**, biến `use_self_hosted` sẽ được đặt thành `true`.
    * Nếu file backup có kích thước **nhỏ hơn hoặc bằng 8GB**, `use_self_hosted` sẽ là `false`.
3.  **Điều kiện `runs-on`:** Bước `integration-test` giờ đây sử dụng điều kiện `runs-on: ${{ needs.prepare-backup.outputs.use_self_hosted == 'true' && 'self-hosted' || 'ubuntu-latest' }}`. Điều này đảm bảo:
    * Các bản backup lớn sẽ được xử lý trên **Self-Hosted Runner** với tài nguyên mạnh mẽ hơn.
    * Các bản backup nhỏ hơn vẫn sử dụng **GitHub Runner mặc định** (`ubuntu-latest`) để tối ưu chi phí và thời gian.
